### PR TITLE
Return ffi's NULL instead of nil from lua_mysql_pushresult()

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Connect to a database.
  - `db` - database name
  - `use_numeric_result` - provide result of the "conn:execute" as ordered list
    (true/false); default value: false
+ - `keep_null` - provide printing null fields in the result of the
+   "conn:execute" (true/false); default value: false
 
 Throws an error on failure.
 
@@ -142,11 +144,26 @@ Throws an error on failure.
 ```
 
 *Example*:
+
+(when `keep_null = false` or is not set on a pool/connection creation)
+
 ```
-tarantool> conn:execute("SELECT ? AS a, 'xx' AS b", 42)
+tarantool> conn:execute("SELECT ? AS a, 'xx' AS b", NULL AS c , 42)
 ---
 - - - a: 42
       b: xx
+- true
+...
+```
+
+(when `keep_null = true` on a pool/connection creation)
+
+```
+tarantool> conn:execute("SELECT ? AS a, 'xx' AS b", NULL AS c, 42)
+---
+- - - a: 42
+      b: xx
+      c: null
 - true
 ...
 ```
@@ -222,6 +239,8 @@ Create a connection pool with count of size established connections.
  - `size` - count of connections in pool
  - `use_numeric_result` - provide result of the "conn:execute" as ordered list
    (true/false); default value: false
+ - `keep_null` - provide printing null fields in the result of the
+   "conn:execute" (true/false); default value: false
 
 Throws an error on failure.
 

--- a/mysql/init.lua
+++ b/mysql/init.lua
@@ -36,7 +36,8 @@ local function conn_get(pool, timeout)
         local status
         status, mysql_conn = driver.connect(pool.host, pool.port or 0,
                                             pool.user, pool.pass,
-                                            pool.db, pool.use_numeric_result)
+                                            pool.db, pool.use_numeric_result,
+                                            pool.keep_null)
         if status < 0 then
             error(mysql_conn)
         end
@@ -165,7 +166,8 @@ local function pool_create(opts)
     for i = 1, opts.size do
         local status, conn = driver.connect(opts.host, opts.port or 0,
                                             opts.user, opts.password,
-                                            opts.db, opts.use_numeric_result)
+                                            opts.db, opts.use_numeric_result,
+                                            opts.keep_null)
         if status < 0 then
             while queue:count() > 0 do
                 local mysql_conn = queue:get()
@@ -185,6 +187,7 @@ local function pool_create(opts)
         db          = opts.db,
         size        = opts.size,
         use_numeric_result = opts.use_numeric_result,
+        keep_null   = opts.keep_null,
 
         -- private variables
         queue       = queue,
@@ -244,7 +247,8 @@ local function connect(opts)
 
     local status, mysql_conn = driver.connect(opts.host, opts.port or 0,
                                               opts.user, opts.password,
-                                              opts.db, opts.use_numeric_result)
+                                              opts.db, opts.use_numeric_result,
+                                              opts.keep_null)
     if status < 0 then
         error(mysql_conn)
     end


### PR DESCRIPTION
Before patch:

```
tarantool> rows = conn:execute('select rand() as w, NULL as x')

---
...

tarantool> rows

---
- - w: 0.81680908595846
...

tarantool> json.encode(rows)

---
- '[{"w":0.81680908595846}]'
...


```

After patch:

```
tarantool> rows = conn:execute('select rand() as w, NULL as x')

---
...

tarantool> rows

---
- - x: null
    w: 0.28386442669096
...

tarantool> json.encode(rows)

---
- '[{"x":null,"w":0.28386442669096}]'
...

```
