### PR TITLE
New result strucure for conn:execute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,4 +51,5 @@ endif(APPLE)
 add_subdirectory(mysql)
 
 add_custom_target(check
-    COMMAND ${PROJECT_SOURCE_DIR}/test/mysql.test.lua)
+    COMMAND ${PROJECT_SOURCE_DIR}/test/mysql.test.lua
+    COMMAND ${PROJECT_SOURCE_DIR}/test/numeric_result.test.lua)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Connect to a database.
  - `user` - username
  - `password` - password
  - `db` - database name
+ - `use_numeric_result` - provide result of the "conn:execute" as ordered list
+   (true/false); default value: false
 
 *Returns*:
 
@@ -85,8 +87,42 @@ Connect to a database.
 Execute a statement with arguments in the current transaction.
 
 *Returns*:
- - `{ { { column1 = value, column2 = value }, ... }, { {column1 = value, ... }, ...}, ...}, true` on success
+
  - `error(reason)` on error
+ - `results, true` on success, where `results` is in the following form:
+
+(when `use_numeric_result = false` or is not set on a pool/connection creation)
+
+```lua
+{
+    { -- result set
+        {column1 = r1c1val, column2 = r1c2val, ...}, -- row
+        {column1 = r2c1val, column2 = r2c2val, ...}, -- row
+        ...
+    },
+    ...
+}
+```
+
+(when `use_numeric_result = true` on a pool/connection creation)
+
+```lua
+{
+    { -- result set
+        rows = {
+            {r1c1val, r1c2val, ...}, -- row
+            {r2c1val, r2c2val, ...}, -- row
+            ...
+        },
+        metadata = {
+            {type = 'long', name = 'col1'}, -- column meta
+            {type = 'long', name = 'col2'}, -- column meta
+            ...
+        },
+    },
+    ...
+}
+```
 
 *Example*:
 ```
@@ -146,6 +182,8 @@ Create a connection pool with count of size established connections.
  - `password` - password
  - `db` - database name
  - `size` - count of connections in pool
+ - `use_numeric_result` - provide result of the "conn:execute" as ordered list
+   (true/false); default value: false
 
 *Returns*
 

--- a/mysql/driver.c
+++ b/mysql/driver.c
@@ -42,6 +42,66 @@
 #define TIMEOUT_INFINITY 365 * 86400 * 100.0
 static const char mysql_driver_label[] = "__tnt_mysql_driver";
 
+struct mysql_connection {
+	MYSQL *raw_conn;
+	int use_numeric_result;
+};
+
+/*
+ * A dumb hash for MySQL field type values.
+ *
+ * Assing zero-based sequential values for field types that are
+ * used by a client:
+ *
+ * - MYSQL_TYPE_DECIMAL .. MYSQL_TYPE_BIT
+ * - MYSQL_TYPE_JSON .. MYSQL_TYPE_GEOMETRY
+ *
+ * Assign FIELD_TYPE_HASH_MAX for an unknown value.
+ *
+ * See enum enum_field_types in
+ * mariadb-connector-c/include/mariadb_com.h.
+ */
+#define FIELD_TYPE_HASH_MAX (MYSQL_TYPE_GEOMETRY + 1)
+#define FIELD_TYPE_HASH(type) (						\
+	((type) >= MYSQL_TYPE_DECIMAL && (type) <= MYSQL_TYPE_BIT) ?	\
+		((type) - MYSQL_TYPE_DECIMAL) :				\
+	((type) >= MYSQL_TYPE_JSON && (type) <= MYSQL_TYPE_GEOMETRY) ?	\
+		((type) - MYSQL_TYPE_JSON + MYSQL_TYPE_BIT -		\
+			MYSQL_TYPE_DECIMAL + 1) :			\
+	FIELD_TYPE_HASH_MAX						\
+)
+
+static const char *mysql_field_type_strs[FIELD_TYPE_HASH_MAX] = {
+	[FIELD_TYPE_HASH(MYSQL_TYPE_DECIMAL)] =     "decimal",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_TINY)] =        "tiny",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_SHORT)] =       "short",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_LONG)] =        "long",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_FLOAT)] =       "float",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_DOUBLE)] =      "double",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_NULL)] =        "null",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_TIMESTAMP)] =   "timestamp",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_LONGLONG)] =    "longlong",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_INT24)] =       "int24",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_DATE)] =        "date",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_TIME)] =        "time",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_DATETIME)] =    "datetime",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_YEAR)] =        "year",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_NEWDATE)] =     "newdate",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_VARCHAR)] =     "varchar",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_BIT)] =         "bit",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_JSON)] =        "json",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_NEWDECIMAL)] =  "newdecimal",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_ENUM)] =        "enum",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_SET)] =         "set",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_TINY_BLOB)] =   "tiny_blob",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_MEDIUM_BLOB)] = "medium_blob",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_LONG_BLOB)] =   "long_blob",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_BLOB)] =        "blob",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_VAR_STRING)] =  "var_string",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_STRING)] =      "string",
+	[FIELD_TYPE_HASH(MYSQL_TYPE_GEOMETRY)] =    "geometry",
+};
+
 static int
 save_pushstring_wrapped(struct lua_State *L)
 {
@@ -58,12 +118,12 @@ safe_pushstring(struct lua_State *L, char *str)
 	return lua_pcall(L, 1, 1, 0);
 }
 
-static inline MYSQL *
+static inline struct mysql_connection *
 lua_check_mysqlconn(struct lua_State *L, int index)
 {
-	MYSQL **conn_p =
-		(MYSQL **)luaL_checkudata(L, index, mysql_driver_label);
-	if (conn_p == NULL || *conn_p == NULL)
+	struct mysql_connection **conn_p = (struct mysql_connection **)
+		luaL_checkudata(L, index, mysql_driver_label);
+	if (conn_p == NULL || *conn_p == NULL || (*conn_p)->raw_conn == NULL)
 		luaL_error(L, "Driver fatal error (closed connection "
 			      "or not a connection)");
 	return *conn_p;
@@ -84,9 +144,9 @@ lua_push_error(struct lua_State *L)
  * Status is -1 if connection is dead or 0 if it is still alive
  */
 static int
-lua_mysql_push_error(struct lua_State *L, MYSQL *conn)
+lua_mysql_push_error(struct lua_State *L, MYSQL *raw_conn)
 {
-	int err = mysql_errno(conn);
+	int err = mysql_errno(raw_conn);
 	switch (err) {
 	case CR_SERVER_LOST:
 	case CR_SERVER_GONE_ERROR:
@@ -95,8 +155,18 @@ lua_mysql_push_error(struct lua_State *L, MYSQL *conn)
 	default:
 		lua_pushnumber(L, 1);
 	}
-	safe_pushstring(L, (char *)mysql_error(conn));
+	safe_pushstring(L, (char *) mysql_error(raw_conn));
 	return 2;
+}
+
+/* Returns string representation of MySQL field type */
+static const char*
+lua_mysql_field_type_to_string(enum enum_field_types type)
+{
+	int hash = FIELD_TYPE_HASH(type);
+	if (hash == FIELD_TYPE_HASH_MAX)
+		hash = FIELD_TYPE_HASH(MYSQL_TYPE_STRING);
+	return mysql_field_type_strs[hash];
 }
 
 /* Push value retrieved from mysql field to lua stack */
@@ -145,31 +215,76 @@ lua_mysql_push_value(struct lua_State *L, MYSQL_FIELD *field,
 static int
 lua_mysql_fetch_result(struct lua_State *L)
 {
-	MYSQL_RES *result = (MYSQL_RES *)lua_topointer(L, 2);
+	struct mysql_connection *conn =
+		(struct mysql_connection *) lua_topointer(L, 1);
+	MYSQL_RES *result = (MYSQL_RES *) lua_topointer(L, 2);
+	MYSQL_FIELD *fields = mysql_fetch_fields(result);
+	const unsigned num_fields = mysql_num_fields(result);
 
 	MYSQL_ROW row;
 	int row_idx = 1;
-	MYSQL_FIELD *fields = mysql_fetch_fields(result);
+
+	/*
+	 * When use_numeric_result is false the table is a result
+	 * set (a return value of this function). Otherwise it is
+	 * a value of "rows" field of the return value.
+	 */
 	lua_newtable(L);
 	do {
 		row = mysql_fetch_row(result);
 		if (!row)
 			break;
-		lua_pushnumber(L, row_idx);
+		/* Create and fill a row table. */
 		lua_newtable(L);
 		unsigned long *len = mysql_fetch_lengths(result);
 		unsigned col_no;
-		for (col_no = 0; col_no < mysql_num_fields(result); ++col_no) {
+		for (col_no = 0; col_no < num_fields; ++col_no) {
 			if (!row[col_no])
 				continue;
-			lua_pushstring(L, fields[col_no].name);
 			lua_mysql_push_value(L, fields + col_no,
 					     row[col_no], len[col_no]);
-			lua_settable(L, -3);
+			if (conn->use_numeric_result) {
+				/* Assign to a column number. */
+				lua_rawseti(L, -2, col_no + 1);
+			} else {
+				/* Assign to a column name. */
+				lua_setfield(L, -2, fields[col_no].name);
+			}
 		}
-		lua_settable(L, -3);
+		lua_rawseti(L, -2, row_idx);
 		++row_idx;
 	} while (true);
+
+	if (!conn->use_numeric_result)
+		return 1;
+
+	/*
+	 * Create a result set table (a return value of the
+	 * function), swap it with the rows table filled above and
+	 * set result_set.rows = rows.
+	 */
+	lua_newtable(L);
+	lua_insert(L, -2);
+	lua_setfield(L, -2, "rows");
+
+	/*
+	 * Create a metadata table and set
+	 * result_set.metadata = metadata.
+	 */
+	lua_newtable(L);
+	unsigned col_no;
+	for (col_no = 0; col_no < num_fields; ++col_no) {
+		/* A column metadata. */
+		lua_newtable(L);
+		lua_pushstring(L, fields[col_no].name);
+		lua_setfield(L, -2, "name");
+		lua_pushstring(L, lua_mysql_field_type_to_string(
+			fields[col_no].type));
+		lua_setfield(L, -2, "type");
+		lua_rawseti(L, -2, col_no + 1);
+	}
+	lua_setfield(L, -2, "metadata");
+
 	return 1;
 }
 
@@ -179,14 +294,15 @@ lua_mysql_fetch_result(struct lua_State *L)
 static int
 lua_mysql_execute(struct lua_State *L)
 {
-	MYSQL *conn = lua_check_mysqlconn(L, 1);
+	struct mysql_connection *conn = lua_check_mysqlconn(L, 1);
+	MYSQL *raw_conn = conn->raw_conn;
 	size_t len;
 	const char *sql = lua_tolstring(L, 2, &len);
 	int err;
 
-	err = mysql_real_query(conn, sql, len);
+	err = mysql_real_query(raw_conn, sql, len);
 	if (err)
-		return lua_mysql_push_error(L, conn);
+		return lua_mysql_push_error(L, raw_conn);
 
 	lua_pushnumber(L, 0);
 	int ret_count = 2;
@@ -194,7 +310,7 @@ lua_mysql_execute(struct lua_State *L)
 
 	lua_newtable(L);
 	while (true) {
-		MYSQL_RES *res = mysql_use_result(conn);
+		MYSQL_RES *res = mysql_use_result(raw_conn);
 		if (res) {
 			lua_pushnumber(L, ++result_no);
 			int fail = 0;
@@ -202,8 +318,8 @@ lua_mysql_execute(struct lua_State *L)
 			lua_pushlightuserdata(L, conn);
 			lua_pushlightuserdata(L, res);
 			fail = lua_pcall(L, 2, 1, 0);
-			if (mysql_errno(conn)) {
-				ret_count = lua_mysql_push_error(L, conn);
+			if (mysql_errno(raw_conn)) {
+				ret_count = lua_mysql_push_error(L, raw_conn);
 				mysql_free_result(res);
 				return ret_count;
 			}
@@ -218,7 +334,7 @@ lua_mysql_execute(struct lua_State *L)
 			}
 			lua_settable(L, -3);
 		}
-		int next_res = mysql_next_result(conn);
+		int next_res = mysql_next_result(raw_conn);
 		if (next_res < 0)
 			break;
 	}
@@ -255,7 +371,7 @@ lua_mysql_stmt_push_row(struct lua_State *L)
 static int
 lua_mysql_execute_prepared(struct lua_State *L)
 {
-	MYSQL *conn = lua_check_mysqlconn(L, 1);
+	MYSQL *raw_conn = lua_check_mysqlconn(L, 1)->raw_conn;
 	size_t len;
 	const char *sql = lua_tolstring(L, 2, &len);
 	int ret_count = 0, fail = 0, error = 0;
@@ -273,7 +389,7 @@ lua_mysql_execute_prepared(struct lua_State *L)
 	lua_pushnumber(L, 0);
 	lua_newtable(L);
 	ret_count = 2;
-	stmt = mysql_stmt_init(conn);
+	stmt = mysql_stmt_init(raw_conn);
 	if ((error = !stmt))
 		goto done;
 	error = mysql_stmt_prepare(stmt, sql, len);
@@ -330,10 +446,13 @@ lua_mysql_execute_prepared(struct lua_State *L)
 	unsigned long col_no;
 	for (col_no = 0; col_no < col_count; ++col_no) {
 		result_binds[col_no].buffer_type = MYSQL_TYPE_STRING;
-		result_binds[col_no].buffer = (char *)malloc(fields[col_no].length);
+		result_binds[col_no].buffer =
+			(char *) malloc(fields[col_no].length);
 		result_binds[col_no].buffer_length = fields[col_no].length;
-		result_binds[col_no].length = (unsigned long *)malloc(sizeof(unsigned long));
-		result_binds[col_no].is_null = (my_bool *)malloc(sizeof(my_bool));
+		result_binds[col_no].length = (unsigned long *) malloc(
+			sizeof(unsigned long));
+		result_binds[col_no].is_null = (my_bool *) malloc(
+			sizeof(my_bool));
 	}
 	mysql_stmt_bind_result(stmt, result_binds);
 	lua_pushnumber(L, 1);
@@ -357,7 +476,7 @@ lua_mysql_execute_prepared(struct lua_State *L)
 
 done:
 	if (error)
-		ret_count = lua_mysql_push_error(L, conn);
+		ret_count = lua_mysql_push_error(L, raw_conn);
 	if (values)
 		free(values);
 	if (param_binds)
@@ -389,12 +508,15 @@ done:
 static int
 lua_mysql_close(struct lua_State *L)
 {
-	MYSQL **conn_p = (MYSQL **)luaL_checkudata(L, 1, mysql_driver_label);
-	if (conn_p == NULL || *conn_p == NULL) {
+	struct mysql_connection **conn_p = (struct mysql_connection **)
+		luaL_checkudata(L, 1, mysql_driver_label);
+	if (conn_p == NULL || *conn_p == NULL || (*conn_p)->raw_conn == NULL) {
 		lua_pushboolean(L, 0);
 		return 1;
 	}
-	mysql_close(*conn_p);
+	mysql_close((*conn_p)->raw_conn);
+	(*conn_p)->raw_conn = NULL;
+	free(*conn_p);
 	*conn_p = NULL;
 	lua_pushboolean(L, 1);
 	return 1;
@@ -406,19 +528,24 @@ lua_mysql_close(struct lua_State *L)
 static int
 lua_mysql_gc(struct lua_State *L)
 {
-	MYSQL **conn_p = (MYSQL **)luaL_checkudata(L, 1, mysql_driver_label);
-	if (conn_p && *conn_p)
-		mysql_close(*conn_p);
-	if (conn_p)
+	struct mysql_connection **conn_p = (struct mysql_connection **)
+		luaL_checkudata(L, 1, mysql_driver_label);
+	if (conn_p != NULL && *conn_p != NULL && (*conn_p)->raw_conn != NULL) {
+		mysql_close((*conn_p)->raw_conn);
+		(*conn_p)->raw_conn = NULL;
+	}
+	if (conn_p != NULL && *conn_p != NULL) {
+		free(*conn_p);
 		*conn_p = NULL;
+	}
 	return 0;
 }
 
 static int
 lua_mysql_tostring(struct lua_State *L)
 {
-	MYSQL *conn = lua_check_mysqlconn(L, 1);
-	lua_pushfstring(L, "MYSQL: %p", conn);
+	MYSQL *raw_conn = lua_check_mysqlconn(L, 1)->raw_conn;
+	lua_pushfstring(L, "MYSQL: %p", raw_conn);
 	return 1;
 }
 
@@ -428,7 +555,7 @@ lua_mysql_tostring(struct lua_State *L)
 int
 lua_mysql_quote(struct lua_State *L)
 {
-	MYSQL *mysql = lua_check_mysqlconn(L, 1);
+	MYSQL *raw_conn = lua_check_mysqlconn(L, 1)->raw_conn;
 	if (lua_gettop(L) < 2) {
 		lua_pushnil(L);
 		return 1;
@@ -441,7 +568,7 @@ lua_mysql_quote(struct lua_State *L)
 		luaL_error(L, "Can't allocate memory for variable");
 	}
 
-	len = mysql_real_escape_string(mysql, sout, s, len);
+	len = mysql_real_escape_string(raw_conn, sout, s, len);
 	lua_pushlstring(L, sout, len);
 	free(sout);
 	return 1;
@@ -465,9 +592,9 @@ mysql_wait_for_io(my_socket socket, my_bool is_read, int timeout)
 static int
 lua_mysql_connect(struct lua_State *L)
 {
-	if (lua_gettop(L) < 5) {
+	if (lua_gettop(L) < 6) {
 		luaL_error(L, "Usage: mysql.connect(host, port, user, "
-			   "password, db)");
+			   "password, db, use_numeric_result)");
 	}
 
 	const char *host = lua_tostring(L, 1);
@@ -475,12 +602,13 @@ lua_mysql_connect(struct lua_State *L)
 	const char *user = lua_tostring(L, 3);
 	const char *pass = lua_tostring(L, 4);
 	const char *db = lua_tostring(L, 5);
+	const int use_numeric_result = lua_toboolean(L, 6);
 
-	MYSQL *conn, *tmp_conn = mysql_init(NULL);
-	if (!tmp_conn) {
+	MYSQL *raw_conn, *tmp_raw_conn = mysql_init(NULL);
+	if (!tmp_raw_conn) {
 		lua_pushinteger(L, -1);
 		int fail = safe_pushstring(L,
-					  "Can not allocate memory for connector");
+			"Can not allocate memory for connector");
 		return fail ? lua_push_error(L): 2;
 	}
 
@@ -494,22 +622,34 @@ lua_mysql_connect(struct lua_State *L)
 		iport = atoi(port); /* 0 is ok */
 	}
 
-	mysql_options(tmp_conn, MYSQL_OPT_IO_WAIT, mysql_wait_for_io);
+	mysql_options(tmp_raw_conn, MYSQL_OPT_IO_WAIT, mysql_wait_for_io);
 
-	conn = mysql_real_connect(tmp_conn, host, user, pass,
+	raw_conn = mysql_real_connect(tmp_raw_conn, host, user, pass,
 		db, iport, usocket,
 		CLIENT_MULTI_STATEMENTS | CLIENT_MULTI_RESULTS);
 
-	if (!conn) {
+	if (!raw_conn) {
 		lua_pushinteger(L, -1);
-		int fail = safe_pushstring(L, (char *)mysql_error(tmp_conn));
-		mysql_close(tmp_conn);
+		int fail = safe_pushstring(L,
+			(char *) mysql_error(tmp_raw_conn));
+		mysql_close(tmp_raw_conn);
 		return fail ? lua_push_error(L) : 2;
 	}
 
 	lua_pushnumber(L, 0);
-	MYSQL **conn_p = (MYSQL **)lua_newuserdata(L, sizeof(MYSQL *));
+	struct mysql_connection *conn = (struct mysql_connection *)
+		calloc(1, sizeof(struct mysql_connection));
+	if (!conn) {
+		lua_pushinteger(L, -1);
+		int fail = safe_pushstring(L,
+			"Can not allocate memory for connector options");
+		return fail ? lua_push_error(L): 2;
+	}
+	struct mysql_connection **conn_p = (struct mysql_connection **)
+		lua_newuserdata(L, sizeof(struct mysql_connection *));
 	*conn_p = conn;
+	(*conn_p)->raw_conn = raw_conn;
+	(*conn_p)->use_numeric_result = use_numeric_result;
 	luaL_getmetatable(L, mysql_driver_label);
 	lua_setmetatable(L, -2);
 
@@ -519,11 +659,11 @@ lua_mysql_connect(struct lua_State *L)
 static int
 lua_mysql_reset(lua_State *L)
 {
-	MYSQL *conn = lua_check_mysqlconn(L, 1);
+	MYSQL *raw_conn = lua_check_mysqlconn(L, 1)->raw_conn;
 	const char *user = lua_tostring(L, 2);
 	const char *pass = lua_tostring(L, 3);
 	const char *db = lua_tostring(L, 4);
-	mysql_change_user(conn, user, pass, db);
+	mysql_change_user(raw_conn, user, pass, db);
 
 	return 0;
 }

--- a/mysql/init.lua
+++ b/mysql/init.lua
@@ -25,7 +25,8 @@ local function conn_get(pool)
     local status
     if mysql_conn == nil then
         status, mysql_conn = driver.connect(pool.host, pool.port or 0,
-                                            pool.user, pool.pass, pool.db)
+                                            pool.user, pool.pass,
+                                            pool.db, pool.use_numeric_result)
         if status < 0 then
             return error(mysql_conn)
         end
@@ -134,7 +135,9 @@ local function pool_create(opts)
     local queue = fiber.channel(opts.size)
 
     for i = 1, opts.size do
-        local status, conn = driver.connect(opts.host, opts.port or 0, opts.user, opts.password, opts.db)
+        local status, conn = driver.connect(opts.host, opts.port or 0,
+                                            opts.user, opts.password,
+                                            opts.db, opts.use_numeric_result)
         if status < 0 then
             while queue:count() > 0 do
                 local mysql_conn = queue:get()
@@ -155,6 +158,7 @@ local function pool_create(opts)
         pass        = opts.password,
         db          = opts.db,
         size        = opts.size,
+        use_numeric_result = opts.use_numeric_result,
 
         -- private variables
         queue       = queue,
@@ -206,7 +210,9 @@ pool_mt = {
 local function connect(opts)
     opts = opts or {}
 
-    local status, mysql_conn = driver.connect(opts.host, opts.port or 0, opts.user, opts.password, opts.db)
+    local status, mysql_conn = driver.connect(opts.host, opts.port or 0,
+                                              opts.user, opts.password,
+                                              opts.db, opts.use_numeric_result)
     if status < 0 then
         return error(mysql_conn)
     end

--- a/test/numeric_result.test.lua
+++ b/test/numeric_result.test.lua
@@ -1,0 +1,51 @@
+#!/usr/bin/env tarantool
+
+package.path = "../?/init.lua;./?/init.lua"
+package.cpath = "../?.so;../?.dylib;./?.so;./?.dylib"
+
+local mysql = require('mysql')
+local tap = require('tap')
+
+local host, port, user, password, db = string.match(os.getenv('MYSQL') or '',
+    "([^:]*):([^:]*):([^:]*):([^:]*):([^:]*)")
+
+local conn, err = mysql.connect({ host = host, port = port, user = user,
+    password = password, db = db, use_numeric_result = true })
+if conn == nil then error(err) end
+
+local p, err = mysql.pool_create({ host = host, port = port, user = user,
+    password = password, db = db, size = 1, use_numeric_result = true })
+if p == nil then error(err) end
+
+function test_mysql_numeric_result(t, conn)
+    t:plan(1)
+    local results, ok = conn:execute('values (1,2,3),(4,5,6),(7,8,9)')
+    local expected = {
+        {
+            rows = {
+                {1, 2, 3},
+                {4, 5, 6},
+                {7, 8, 9},
+            },
+            metadata = {
+                {type = 'long', name = '1'},
+                {type = 'long', name = '2'},
+                {type = 'long', name = '3'},
+            }
+        }
+    }
+
+    t:is_deeply({ok, results}, {true, expected}, 'results contain numeric rows')
+end
+
+local test = tap.test('use_numeric_result option')
+test:plan(2)
+
+test:test('use_numeric_result via connection', test_mysql_numeric_result, conn)
+
+local pool_conn = p:get()
+test:test('use_numeric_result via pool', test_mysql_numeric_result, pool_conn)
+p:put(pool_conn)
+p:close()
+
+os.exit(test:check() == true and 0 or 1)


### PR DESCRIPTION
Hi! There is a problem with how the "conn:execute" returns the result:
```
{ { { column1 = value, column2 = value }, ... }, { {column1 = value, ... }, ...}, ...}, true
```
In this structure, the order of the columns is not guaranteed.

As a result, when the SQL query looks like "values (1,2,3),(4,5,6),(7,8,9)"
we receive this result:
```
{{
    {["2"] = 2, ["1"] = 1, ["3"] = 3},
    {["2"] = 5, ["1"] = 4, ["3"] = 6},
    {["2"] = 8, ["1"] = 7, ["3"] = 9}
}}
```
We need to ensure the order is the same as returned by mysql c-connector.

In this merge request new structure changed like this:
```
{{
  result = {
    {1,2,3},
    {4,5,6},
    {7,8,9}
  },
  columns = {"1","2","3"}
}}
```
This structure retains the order returned by the mysql driver.
A side effect is that the structure has become more compact.
But this implementation breaks backward compatibility.
How can we maintain backward compatibility in this case?

