### PR TITLE
travis-ci: update distros and target repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,16 @@ deploy:
     on:
       branch: master
       condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb,dsc}
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
 
   # Deploy packages to PackageCloud from tags
   # see:
@@ -145,6 +155,16 @@ deploy:
   - provider: packagecloud
     username: tarantool
     repository: "2_3"
+    token: ${PACKAGECLOUD_TOKEN}
+    dist: ${OS}/${DIST}
+    package_glob: build/*.{rpm,deb,dsc}
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: -n "${OS}" && -n "${DIST}" && -n "${PACKAGECLOUD_TOKEN}"
+  - provider: packagecloud
+    username: tarantool
+    repository: "2_4"
     token: ${PACKAGECLOUD_TOKEN}
     dist: ${OS}/${DIST}
     package_glob: build/*.{rpm,deb,dsc}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,18 +33,18 @@ jobs:
       env: OS=fedora DIST=29
     - name: "Fedora 30 build + deploy RPM"
       env: OS=fedora DIST=30
+    - name: "Fedora 31 build + deploy RPM"
+      env: OS=fedora DIST=31
     - name: "Ubuntu Trusty (14.04) build + deploy DEB"
       env: OS=ubuntu DIST=trusty
     - name: "Ubuntu Xenial (16.04) build + deploy DEB"
       env: OS=ubuntu DIST=xenial
     - name: "Ubuntu Bionic (18.04) build + deploy DEB"
       env: OS=ubuntu DIST=bionic
-    - name: "Ubuntu Cosmic (18.10) build + deploy DEB"
-      env: OS=ubuntu DIST=cosmic
-    - name: "Ubuntu Disco (19.04) build + deploy DEB"
-      env: OS=ubuntu DIST=disco
     - name: "Ubuntu Eoan (19.10) build + deploy DEB"
       env: OS=ubuntu DIST=eoan
+    - name: "Ubuntu Focal (20.04) build + deploy DEB"
+      env: OS=ubuntu DIST=focal
     - name: "Debian Jessie (8) build + deploy DEB"
       env: OS=debian DIST=jessie
     - name: "Debian Stretch (9) build + deploy DEB"


### PR DESCRIPTION
Added Fedora 31 and Ubuntu Focal. Dropped EOL distros: Ubuntu Cosmic and Ubuntu Disco: I guess CI will fail on them at repositories metadata updating. Those targets are for deploy RPM / Deb packages to our repositories.

Deploy to tarantool-2.4 repository in addition to existing ones.

Fixes #40