### PR TITLE
Handle connections from a pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ Update the connection authentication settings.
 
 Throws an error on failure.
 
+### `conn:close()`
+
+Close the individual connection or return it to a pool.
+
+Throws an error on failure.
+
+*Returns*: `true`
+
 ### `pool = mysql.pool_create(opts)`
 
 Create a connection pool with count of size established connections.
@@ -246,6 +254,12 @@ Return a connection to connection pool.
 *Options*
 
  - `conn` - a connection
+
+### `pool:close()`
+
+Close all connections in pool.
+
+*Returns*: `true`
 
 ## Comments
 

--- a/mysql/init.lua
+++ b/mysql/init.lua
@@ -35,8 +35,8 @@ local function conn_get(pool, timeout)
     -- A timeout was reached.
     if mysql_conn == nil then return nil end
 
-    local status
     if mysql_conn == POOL_EMPTY_SLOT then
+        local status
         status, mysql_conn = driver.connect(pool.host, pool.port or 0,
                                             pool.user, pool.pass,
                                             pool.db, pool.use_numeric_result)
@@ -163,9 +163,7 @@ local function pool_create(opts)
                 local mysql_conn = queue:get()
                 mysql_conn:close()
             end
-            if status < 0 then
-                error(conn)
-            end
+            error(conn)
         end
         queue:put(conn)
     end

--- a/mysql/init.lua
+++ b/mysql/init.lua
@@ -201,7 +201,7 @@ local function pool_close(self)
             mysql_conn:close()
         end
     end
-    return 1
+    return true
 end
 
 -- Returns connection


### PR DESCRIPTION
Patchset includes:
* Update connection management for connection pool
* Change the return type of pool:close() to bool
* Description of conn:close() and pool:close() added to README.md
* Code cleanup

Fixed #33 

ChangeLog:
Update connection management for connection pool.
Change the return type of pool:close() to bool.