### PR TITLE
travis-ci: fix tarantool repository enabling

### DIFF
--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -4,13 +4,13 @@ set -exu  # Strict shell (w/o -o pipefail)
 
 REPO=${TARANTOOL_REPO:-1.10}
 
-curl http://download.tarantool.org/tarantool/${REPO}/gpgkey | sudo apt-key add -
+curl -LsSf https://download.tarantool.org/tarantool/${REPO}/gpgkey | sudo apt-key add -
 release=`lsb_release -c -s`
 
 sudo rm -f /etc/apt/sources.list.d/*tarantool*.list
 sudo tee /etc/apt/sources.list.d/tarantool_${REPO}.list <<- EOF
-deb http://download.tarantool.org/tarantool/${REPO}/ubuntu/ $release main
-deb-src http://download.tarantool.org/tarantool/${REPO}/ubuntu/ $release main
+deb https://download.tarantool.org/tarantool/${REPO}/ubuntu/ $release main
+deb-src https://download.tarantool.org/tarantool/${REPO}/ubuntu/ $release main
 EOF
 
 sudo apt-get update


### PR DESCRIPTION
First, download.tarantool.org may use redirects, so curl -L (--location)
should be used. At least now it redirects from http to https when we ask
for a gpg key. In future it may redirect to another backend.

Next, added -s (--silent, don't show a progress meter), -S
(--show-error, show an error message on stderr), -f (--fail, no output
to stdout at error) for curl, because curl command is part of a shell
pipeline and this way the next pipeline command will not receive an
unexpected data like 404 Not found HTML page.

While I'm here, I changed all URLs to https, because those http URLs
anyway redirect to https.