### PR TITLE
build: link libucontext for Alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   tarantool-devel packages).
 * MySQL 5.1 header files (libmysqlclient-dev package).
 * OpenSSL development package.
+* libucontext (only for Alpine).
 
 If you prefer to install the connector using a system package manager you don't
 need to manually install dependencies.

--- a/mysql/CMakeLists.txt
+++ b/mysql/CMakeLists.txt
@@ -1,6 +1,27 @@
 add_library(driver SHARED driver.c)
 add_dependencies(driver mariadbclient)
 target_link_libraries(driver mariadbclient)
+
+# Check 'makecontext', 'getcontext', 'setcontext' and 'swapcontext' symbols.
+
+include(CheckLibraryExists)
+check_library_exists(c makecontext "" HAVE_UCONTEXT_LIBC)
+
+if (NOT HAVE_UCONTEXT_LIBC)
+    # Search for libucontext.
+    find_package(PkgConfig)
+    if (PKG_CONFIG_FOUND)
+        pkg_check_modules(libucontext IMPORTED_TARGET libucontext)
+        if (libucontext_FOUND)
+            target_link_libraries(driver PkgConfig::libucontext)
+        else()
+            message(FATAL_ERROR "Missing 'makecontext', 'getcontext', 'setcontext' or 'swapcontext' symbol in libc and no libucontext found.")
+        endif()
+    else()
+        message(FATAL_ERROR "PkgConfig is required to link libucontext.")
+    endif()
+endif()
+
 set_target_properties(driver PROPERTIES PREFIX "" OUTPUT_NAME "driver")
 install(TARGETS driver LIBRARY DESTINATION ${TARANTOOL_INSTALL_LIBDIR}/mysql)
 install(FILES init.lua DESTINATION ${TARANTOOL_INSTALL_LUADIR}/mysql)


### PR DESCRIPTION
Fibers library requires 'makecontext', 'getcontext', 'setcontext' and 'swapcontext' symbols. There are no such symbols in Alpine musl c library implementation [1]: third party library expected to be used for them. This patch adds PkgConfig and libucontext requirement to CMake if ucontext wasn't found in libc and libucontext linking.

1. https://www.openwall.com/lists/musl/2018/01/29/2

Closes #65