### PR TITLE
Potential yield in connection from pool GC

### DIFF
--- a/.github/workflows/fast_testing.yml
+++ b/.github/workflows/fast_testing.yml
@@ -19,7 +19,7 @@ jobs:
         tarantool:
           - '1.10'
           - '2.8'
-          - '2.9'
+          - '2.10'
 
     env:
       MYSQL_HOST: 127.0.0.1

--- a/mysql/init.lua
+++ b/mysql/init.lua
@@ -61,6 +61,7 @@ local function conn_get(pool, timeout)
         pool:put(self)
         return true
     end
+    conn.pool = pool
     return conn
 end
 
@@ -216,6 +217,12 @@ end
 -- Free binded connection
 local function pool_put(self, conn)
     if conn.usable then
+        if conn.pool ~= self then
+            local msg = ('Trying to put connection from pool %s to pool %s'):
+                        format(conn.pool, self)
+            error(msg)
+        end
+
         self.queue:put(conn_put(conn))
     else
         error('Connection is not usable')

--- a/mysql/init.lua
+++ b/mysql/init.lua
@@ -137,12 +137,12 @@ conn_mt = {
             end
             self.queue:put(true)
         end,
-	quote = function(self, value)
+        quote = function(self, value)
             conn_acquire_lock(self)
             local ret = self.conn:quote(value)
             self.queue:put(true)
             return ret
-	end
+        end
     }
 }
 


### PR DESCRIPTION
### api: forbid putting to a wrong pool

Connection pools allow user to get connections and explicitly return them back. But it is allowed to return connection to any pool. This could easily lead to pool queue overflow. Each pool allocates fiber channel of connection count size to store connections. If user would put several extra connections to a pool, next puts will lead to `pool:put()` hangup since channel will be full and `channel:put()` is used without timeout and possible error processing, relying on get/put+gc balance.

Part of #67

### gc: prevent potential fiber yield

Yielding in gc is prohibited since Tarantool 2.6.0-138-gd3f1dd720, 2.5.1-105-gc690b3337, 2.4.2-89-g83037df15, 1.10.7-47-g8099cb053. If fiber yield happens in object gc, Tarantool process exits with code 1.

Gc hook of a connection from a connection pool calls `pool.queue:put(...)`. Fiber `channel:put()` may yield if the channel
is full. `channel:put()`/`channel:get()` in mysql driver connection pool is balanced:
* the channel capacity is equal to the connection count;
* pool create fills the channel with multiple `channel:put()`s   all the way through;
* `pool:get()` causes single `channel:get()` and creates a connection object with gc hook;
* `pool:put()` causes single `channel:put()` and removes gc hook;
* gc hook causes single `channel:put()`.

There are no other cases of `channel:put()`. `pool:put()` and gc hook cannot be executed both in the same time: either a connection is used inside `pool:put()` and won't be garbage collected or a connection is no longer used anywhere else (including `pool:put()`) and it will be garbage collected. So now there are no valid cases when gc hook may yield unless someone messes up with pool queue. Messing up with pool queue anyway breaks a connection pool internal logic, so we make the pool unavailable in that case.

Delayed gc should not break existing logic. If `pool:get()` is called, we expect to get a connection after gc and it's not yet returned, `channel:get()` will yield and trigger all planned returns.

Closes #67