### PR TITLE
driver: make `luaL_pushnull()` non-static

### DIFF
--- a/mysql/driver.c
+++ b/mysql/driver.c
@@ -49,7 +49,7 @@ static int luaL_nil_ref = LUA_REFNIL;
  * Can be used as replacement of nil in Lua tables.
  * @param L stack
  */
-static inline void
+void
 luaL_pushnull(struct lua_State *L)
 {
 	lua_rawgeti(L, LUA_REGISTRYINDEX, luaL_nil_ref);


### PR DESCRIPTION
Tarantool will make this method public in:
https://github.com/tarantool/tarantool/pull/10208/commits/878c0d04bcf7410f3ca4a02fcc1bf979cc724f29

This patch fixes compilation error:
```
./mysql/driver.c:53:1: error: static declaration of ‘luaL_pushnull’ follows non-static declaration
   53 | luaL_pushnull(struct lua_State *L)
      | ^~~~~~~~~~~~~
```